### PR TITLE
Add a function to assign a setting to allow testing for emptiness/non-existence in templates.

### DIFF
--- a/settings/models.py
+++ b/settings/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.template.defaultfilters import linebreaksbr
 
 from cms.apps.media.models import ImageRefField
 
@@ -48,3 +49,11 @@ class Setting(models.Model):
 
     def __str__(self):
         return self.name
+
+    def value(self):
+        return {
+            'string': self.string,
+            'text': linebreaksbr(self.text),
+            'number': self.number,
+            'image': self.image.file.url if self.image else '',
+        }[self.type]

--- a/settings/templatetags/settings.py
+++ b/settings/templatetags/settings.py
@@ -1,5 +1,4 @@
 from django import template
-from django.template.defaultfilters import linebreaksbr
 
 from ..models import Setting
 
@@ -7,15 +6,18 @@ register = template.Library()
 
 
 @register.simple_tag()
+def setting(key):
+    # Get the setting by key
+    try:
+        return Setting.objects.get(key=key).value()
+    except Setting.DoesNotExist:
+        return key
+
+
+@register.assignment_tag()
 def get_setting(key):
     # Get the setting by key
     try:
-        setting = Setting.objects.get(key=key)
-        return {
-            'string': setting.string,
-            'text': linebreaksbr(setting.text),
-            'number': setting.number,
-            'image': setting.image.file.url if setting.image else '',
-        }[setting.type]
+        return Setting.objects.get(key=key).value()
     except Setting.DoesNotExist:
-        return key
+        return None


### PR DESCRIPTION
It seems more natural to name the assignment tag `get_setting`, so the new tag takes over the old name in this change, with the old tag being renamed `setting`.

A consequence of this is that the function to get the value (test setting type, return appropriate field) is now a method on the object; that it can now be used outside of templates without duplicating the same code is a nice side-effect.